### PR TITLE
Changed compile flags for extra speed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,8 @@ colcon build \
     --event-handlers console_direct+ \
     --packages-ignore lance \
     --cmake-args \
+        -DCMAKE_CXX_FLAGS="-march=native" \
+        -DCMAKE_C_FLAGS="-march=native" \
         -Wno-dev \
         -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
         ${ROBOT_TARGET}
@@ -45,6 +47,8 @@ colcon build \
     --event-handlers console_direct+ \
     --packages-select lance \
     --cmake-args \
+        -DCMAKE_CXX_FLAGS="-march=native" \
+        -DCMAKE_C_FLAGS="-march=native" \
         -Wno-dev \
         -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
         ${ROBOT_TARGET}


### PR DESCRIPTION
Let's use `-march=native`
This tells gcc to compile for the computer it's running on, even if the resulting binary would fail on other machines. This compiler flag gives a 20% performance boost to Stockfish 